### PR TITLE
Refactor WS2812_Cal_Bri

### DIFF
--- a/LCM/Code/App/task.c
+++ b/LCM/Code/App/task.c
@@ -210,7 +210,6 @@ void WS2812_Boot(void) {
 	WS2812_Refresh();//ˢ����ʾ
 }
 
-uint8_t brightness = 1;
 /**************************************************
  * @brie   :WS2812_Cal_Bri()
  * @note   :��������
@@ -219,6 +218,9 @@ uint8_t brightness = 1;
  **************************************************/
 uint8_t WS2812_Cal_Bri(uint8_t cnt)
 {
+	static uint8_t brightness = 1;
+
+	// Update brightness
 	if(cnt < 50)
 	{
 		brightness++;
@@ -228,12 +230,12 @@ uint8_t WS2812_Cal_Bri(uint8_t cnt)
 		brightness--;
 	}
 
+	// Clamp brightness
 	if(brightness < 1)
 	{
 		brightness = 1;
 	}
-
-	if(brightness > 50)
+	else if(brightness > 50)
 	{
 		brightness = 50;
 	}


### PR DESCRIPTION
- Move global `uint8_t brightness` inside `WS2812_Cal_Bri` as a `static uint8_t` – improves scope clarity.
- Add comments.
- Add `else` to the brightness clamping code block to eliminate unnecessary comparison.  

As far as I understand, the global `uint8_t brightness` is only referenced inside of `WS2812_Cal_Bri`. I do not have an LCM (let alone a FW ADV) to test this on, so this change is untested.